### PR TITLE
make wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ LABEL maintainer="thelamer"
 
 # title
 ENV TITLE=Zotero \
-    NO_GAMEPAD=true
+    NO_GAMEPAD=true \
+    SELKIES_DESKTOP=true \
+    PIXELFLUX_WAYLAND=true \
+    NO_FULL=true
 
 RUN \
   echo "**** add icon ****" && \
@@ -61,6 +64,13 @@ RUN \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/* \
+    /usr/share/applications/debian-uxterm.desktop \
+    /usr/share/applications/debian-xterm.desktop \
+    /usr/share/applications/footclient.desktop \
+    /usr/share/applications/foot-server.desktop \
+    /usr/share/applications/st.desktop \
+    /usr/share/applications/tint2conf.desktop \
+    /usr/share/applications/tint2.desktop \
     /var/lib/apt/lists/* \
     /var/tmp/*
 

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **30.03.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **21.03.26:** - Use Wayland ozone platform for chromium fixes scaling and acceleration.
 * **28.12.25:** - Add Wayland init logic.
 * **22.09.25:** - Rebase to Debian Trixie.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -106,6 +106,7 @@ init_diagram: |
   "zotero:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "30.03.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "21.03.26:", desc: "Use Wayland ozone platform for chromium fixes scaling and acceleration."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "22.09.25:", desc: "Rebase to Debian Trixie."}

--- a/root/defaults/autostart_wayland
+++ b/root/defaults/autostart_wayland
@@ -1,3 +1,13 @@
 #!/bin/bash
 
+if [ ! -f "${HOME}/Desktop/zotero.desktop" ]; then
+  cp /usr/share/applications/zotero.desktop "${HOME}/Desktop/"
+  cp /usr/share/applications/chromium.desktop "${HOME}/Desktop/"
+fi
+
+touch "${HOME}/.config/panel-reload"
+gio mime x-scheme-handler/http chromium.desktop
+gio mime x-scheme-handler/https chromium.desktop
+gio mime application/x-terminal-emulator foot.desktop
+
 zotero


### PR DESCRIPTION
Refactor wayland side to use selkies-desktop, ensure proper mime type linking as this app uses it heavily, swap to wayland as default. 